### PR TITLE
Update getBroadlinkSharedData.py

### DIFF
--- a/getBroadlinkSharedData.py
+++ b/getBroadlinkSharedData.py
@@ -118,4 +118,4 @@ for i in range(0, len(jsonIrCodeData)):
             code_base64 = base64.b64encode(code_bytes)
             code_base64 = code_base64.decode('utf-8')
             result = "Button Name: " + buttonNames[j] + "\r\n" + "Button ID: " + str(jsonIrCodeData[i]['buttonId']) + "\r\n" + "Code: " + code  + "\r\n" + "Base64: " + "\r\n" + code_base64 + "\r\n"
-            codesFile.write(result.encode('utf-8'))
+            codesFile.write(result)


### PR DESCRIPTION
Write result as string not bytes. Required for script to run under python3.

Without this change, script will return the following error: Traceback (most recent call last):
  File "getBroadlinkSharedData.py", line 121, in <module>
    codesFile.write(result.encode('utf-8'))
TypeError: write() argument must be str, not bytes